### PR TITLE
Use shimming for promise.any, update to node 14.16.1, switch to alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12.18.3-buster
+FROM node:14.16.1-alpine3.13
 
 ARG COMMIT=""
 LABEL commit=${COMMIT}

--- a/pages/config.vue
+++ b/pages/config.vue
@@ -533,7 +533,8 @@ export default {
         HostName: client.Name,
       };
       try {
-        resolution = await any(promises);
+        any.shim();
+        resolution = await Promise.any(promises);
         resolvedClient.Reachable = true;
         resolvedClient.Address = resolution.address;
       } catch {

--- a/pages/globalconfig.vue
+++ b/pages/globalconfig.vue
@@ -789,7 +789,8 @@ export default {
           }
         }
       }
-      return await any(promises);
+      any.shim();
+      return await Promise.any(promises);
     },
     getClients: async function () {
       let resolution = await this.resolveClients();

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -270,7 +270,8 @@ export default {
         HostName: client.Name,
       };
       try {
-        resolution = await any(promises);
+        any.shim();
+        resolution = await Promise.any(promises);
         resolvedClient.Reachable = true;
         resolvedClient.Address = resolution.address;
       } catch {

--- a/pages/jobs.vue
+++ b/pages/jobs.vue
@@ -634,7 +634,8 @@ export default {
           }
         }
       }
-      return await any(promises);
+      any.shim();
+      return await Promise.any(promises);
     },
     getClients: async function () {
       let resolution = await this.resolveClients();


### PR DESCRIPTION
Use shimming to allow browsers to use their own Promise.any() if available.
Bump to node 14.16.1 as it now works perfectly fine and use alpine as it greatly reduces the image size by about half.